### PR TITLE
EW-14120: Automatically get enhanced debug headers

### DIFF
--- a/src/main/java/actions/RunCodeProfilerAction.java
+++ b/src/main/java/actions/RunCodeProfilerAction.java
@@ -2,37 +2,66 @@ package actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.progress.ProgressManager;
 import org.jetbrains.annotations.NotNull;
 import ui.CodeProfilerToolWindow;
 import ui.EdgeWorkerNotification;
 import utils.DnsService;
 import utils.EdgeworkerWrapper;
 
-import javax.naming.NamingException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Objects;
 
 public class RunCodeProfilerAction extends AnAction {
     private final CodeProfilerToolWindow codeProfiler;
+    private final HashMap<String, HeaderCache> authCache;
+    private final int cacheExpiryInSeconds = 115 * 60; // token expiry is 120 minutes
 
     public RunCodeProfilerAction(CodeProfilerToolWindow codeProfiler) {
         super();
         this.codeProfiler = codeProfiler;
+        this.authCache = new HashMap<>();
+    }
+
+    /**
+     * Get header name value pair from cache
+     *
+     * @param key cache key
+     * @return String[] containing header name and value or null if the value does not exist or is expired
+     */
+    private String[] getAuthCache(String key) {
+        HeaderCache val = authCache.get(key);
+        if (val != null) {
+            if (val.created > Instant.now().getEpochSecond() - cacheExpiryInSeconds) {
+                return new String[]{val.name, val.value};
+            } else {
+                authCache.remove(key);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Add a new header name value pair to the cache
+     *
+     * @param key        cache key
+     * @param headerName header name
+     * @param value      header value
+     */
+    private void putAuthCache(String key, String headerName, String value) {
+        authCache.put(key, new HeaderCache(headerName, value));
     }
 
     /**
      * @param hostname String: hostname used to get staging IP address from
      * @return InetAddress: IP address of the staging hostname
-     * @throws NamingException      thrown if the CNAME lookup for the hostname fails
-     * @throws UnknownHostException thrown if the CNAME IP address cannot be resolved
+     * @throws Exception thrown if we cannot get the staging IP address from the hostname
      */
-    private InetAddress getStagingIp(String hostname) throws NamingException, UnknownHostException {
-        if (hostname.contains("://")) {
-            // remove protocol from hostname
-            hostname = hostname.split("(://)")[1];
-        }
-
+    private InetAddress getStagingIp(String hostname) throws Exception {
         // Check if local url
         String[] localAddresses = new String[]{
                 "127.0.0.1",
@@ -59,6 +88,7 @@ public class RunCodeProfilerAction extends AnAction {
                 ".akamaized-staging.net"
         };
         String cname = null;
+
         for (int i = 0; i < 4; i++) {
             if (hostname.endsWith(edgeHostEndings[i]) || hostname.endsWith(edgeHostStagingEndings[i])) {
                 // hostname is already the cname
@@ -68,17 +98,102 @@ public class RunCodeProfilerAction extends AnAction {
         }
         if (cname == null) {
             // get cname if we don't already have it
-            cname = DnsService.getCNAME(hostname)[0];
+            try {
+                cname = DnsService.getCNAME(hostname)[0];
+            } catch (Exception exception) {
+                throw new Exception("Error: Unable to resolve CNAME for hostname: " + hostname);
+
+            }
         }
 
-        // Get staging name if needed
-        String beginning = cname.substring(0, cname.indexOf(".net"));
-        if (!beginning.endsWith("-staging")) {
-            cname = beginning + "-staging.net";
+        // Get staging IP
+        try {
+            String beginning = cname.substring(0, cname.indexOf(".net"));
+            if (!beginning.endsWith("-staging")) {
+                // get staging cname if needed
+                cname = beginning + "-staging.net";
+            }
+            return InetAddress.getByName(cname);
+        } catch (Exception exception) {
+            throw new Exception("Error: Unable to get staging IP address for hostname : " + hostname);
+        }
+    }
+
+    /**
+     * Get secure trace header used to make a profiling request. Will use cached header if available.
+     *
+     * @param edgeworkerWrapper wrapper instance to call CLI with
+     * @param hostname          hostname to get headers for
+     * @return String[]: header name value pair
+     * @throws Exception thrown if we cannot get the secure trace headers
+     */
+    private String[] getSecureTraceHeader(EdgeworkerWrapper edgeworkerWrapper, String hostname) throws Exception {
+        String[] secureTraceTokenHeader = getAuthCache(hostname);
+        if (secureTraceTokenHeader != null) {
+            return secureTraceTokenHeader;
+        }
+        String edgeWorkersAuthResponseString = edgeworkerWrapper.getEdgeWorkersAuthString(hostname);
+
+        // Separate header name and value since they are returned as a string by the API
+        String secureTraceHeader;
+        String secureTraceValue;
+        try {
+            secureTraceHeader = edgeWorkersAuthResponseString.substring(0, edgeWorkersAuthResponseString.indexOf(": "));
+            secureTraceValue = edgeWorkersAuthResponseString.substring(edgeWorkersAuthResponseString.indexOf(": ") + 2);
+        } catch (IndexOutOfBoundsException exception) {
+            // this shouldn't ever really happen but is useful in the rare chance that it ever does
+            throw new Exception("Error: Unable to get enhanced debug headers: Invalid response");
         }
 
-        // Get IP for CNAME
-        return InetAddress.getByName(cname);
+        // cache auth token
+        putAuthCache(hostname, secureTraceHeader, secureTraceValue);
+        return new String[]{secureTraceHeader, secureTraceValue};
+    }
+
+    /**
+     * Creates a new thread and runs the various steps we need to get profiling data from the hostname.
+     *
+     * @param edgeworkerWrapper wrapper instance to call CLI with
+     * @param event             event which triggered the action
+     * @param hostname          hostname to profile
+     * @param eventHandler      event handler to profile
+     * @param filePath          profiling data directory
+     * @param fileName          profiling data file name
+     * @param headers           any additional headers to include in the http request
+     */
+    private void profileEdgeWorker(EdgeworkerWrapper edgeworkerWrapper, AnActionEvent event, String hostname, String eventHandler, String filePath, String fileName, ArrayList<String[]> headers) {
+        codeProfiler.setIsLoading(true);
+        ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
+            try {
+                // Get staging IP
+                ProgressManager.getInstance().getProgressIndicator().setText("Determining staging IP address...");
+                InetAddress stagingIp = getStagingIp(hostname);
+
+                // Get secure trace headers
+                ProgressManager.getInstance().getProgressIndicator().setText("Generating enhanced debug header...");
+                String[] secureTraceTokenHeader = getSecureTraceHeader(edgeworkerWrapper, hostname);
+                headers.add(secureTraceTokenHeader);
+
+                // Make http call
+                //ProgressManager.getInstance().getProgressIndicator().setText("Getting profiling data...");
+
+
+                System.out.println(stagingIp.toString());
+                System.out.println(Arrays.toString(secureTraceTokenHeader));
+
+                // convert profile to html & js
+                // String pathToHtml = edgeworkerWrapper.getEdgeWorkerProfilingHtml(edgeWorkerURL, eventHandler);
+                // bundling speedscope???
+                // render html
+
+            } catch (Exception exception) {
+                EdgeWorkerNotification.notifyError(null,
+                        Objects.requireNonNullElse(exception.getMessage(), "Error: Unable to profile hostname: " + hostname));
+                exception.printStackTrace();
+            } finally {
+                codeProfiler.setIsLoading(false);
+            }
+        }, "Profile EdgeWorker", false, event.getProject());
     }
 
     @Override
@@ -86,26 +201,32 @@ public class RunCodeProfilerAction extends AnAction {
         if (!new EdgeworkerWrapper().checkIfAkamaiCliInstalled()) {
             return;
         }
+        EdgeworkerWrapper edgeworkerWrapper = new EdgeworkerWrapper(e.getProject());
         String edgeWorkerURL = codeProfiler.getEdgeWorkerURL();
         String eventHandler = codeProfiler.getSelectedEventHandler();
         String filePath = codeProfiler.getFilePath();
         String fileName = codeProfiler.getFileName();
-        String[][] headers = codeProfiler.getHeaders();
-        InetAddress stagingIp;
-        //EdgeworkerWrapper edgeworkerWrapper = new EdgeworkerWrapper(e.getProject());
+        ArrayList<String[]> headers = codeProfiler.getHeaders();
+        String hostname;
 
-        System.out.println(edgeWorkerURL + " " + eventHandler + " " + filePath + " " + fileName + " " + Arrays.deepToString(headers));
-        try {
-            stagingIp = getStagingIp(edgeWorkerURL);
-            System.out.println(stagingIp.toString());
-        } catch (Exception exception) {
-            EdgeWorkerNotification.notifyError(null, "Error: Unable to get staging IP for URL: " + edgeWorkerURL);
+        if (edgeWorkerURL.contains("://")) {
+            // remove protocol from hostname
+            hostname = edgeWorkerURL.split("(://)")[1];
+        } else {
+            hostname = edgeWorkerURL;
         }
-        // get secure trace token
-        // make http call
-        // convert profile to html & js
-        // String pathToHtml = edgeworkerWrapper.getEdgeWorkerProfilingHtml(edgeWorkerURL, eventHandler);
-        // bundling speedscope???
-        // render html
+        profileEdgeWorker(edgeworkerWrapper, e, hostname, eventHandler, filePath, fileName, headers);
+    }
+
+    static class HeaderCache {
+        protected final long created;
+        protected final String name;
+        protected final String value;
+
+        public HeaderCache(String name, String value) {
+            this.created = Instant.now().getEpochSecond();
+            this.name = name;
+            this.value = value;
+        }
     }
 }

--- a/src/main/java/ui/CodeProfilerToolWindow.java
+++ b/src/main/java/ui/CodeProfilerToolWindow.java
@@ -31,6 +31,7 @@ public class CodeProfilerToolWindow {
     private JBHintTextField fileName;
     private DefaultTableModel tableModel;
     private JBTable headersTable;
+    private boolean isLoading;
     private boolean shouldValidate;
     private Border defaultBorder;
     private JBLabel edgeWorkerURLValueErrorLabel;
@@ -41,6 +42,7 @@ public class CodeProfilerToolWindow {
     public CodeProfilerToolWindow() {
         this.resourceBundle = ResourceBundle.getBundle("ActionBundle");
         this.panel = new SimpleToolWindowPanel(false, false);
+        this.isLoading = false;
         this.shouldValidate = false;
         ActionManager actionManager = ActionManager.getInstance();
         if (null != actionManager.getAction(resourceBundle.getString("action.runCodeProfiler.id"))) {
@@ -73,7 +75,7 @@ public class CodeProfilerToolWindow {
         }
     }
 
-    public String[][] getHeaders() {
+    public ArrayList<String[]> getHeaders() {
         ArrayList<String[]> tableData = new ArrayList<>();
         for (int i = 0; i < tableModel.getRowCount(); i++) {
             String[] header = new String[2];
@@ -81,7 +83,15 @@ public class CodeProfilerToolWindow {
             header[1] = (String) tableModel.getValueAt(i, 1);
             tableData.add(header);
         }
-        return tableData.toArray(new String[0][]);
+        return tableData;
+    }
+
+    public boolean getIsLoading() {
+        return isLoading;
+    }
+
+    public void setIsLoading(boolean isLoading) {
+        this.isLoading = isLoading;
     }
 
     private void addRow() {
@@ -263,6 +273,7 @@ public class CodeProfilerToolWindow {
         // Run & Reset Buttons
         JButton runButton = new JButton("Run Profiler");
         runButton.addActionListener(e -> handleRun(runButton));
+        runButton.setEnabled(!isLoading);
         runButton.setDefaultCapable(true);
         JButton resetButton = new JButton("Reset");
         resetButton.addActionListener(e -> handleReset());

--- a/src/main/java/utils/EdgeworkerWrapper.java
+++ b/src/main/java/utils/EdgeworkerWrapper.java
@@ -21,18 +21,23 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.wm.*;
-import com.intellij.ui.content.*;
+import com.intellij.openapi.wm.RegisterToolWindowTask;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowAnchor;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import com.intellij.ui.content.ContentManager;
 import config.EdgeWorkersConfig;
 import config.SettingsService;
 import org.jetbrains.annotations.NotNull;
 import ui.CheckAkamaiCLIDialog;
 import ui.EdgeWorkerNotification;
+
 import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.io.Reader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -47,21 +52,21 @@ public class EdgeworkerWrapper implements Disposable {
     private ResourceBundle resourceBundle;
     private ConsoleView console;
 
-    public EdgeworkerWrapper(@NotNull Project project){
+    public EdgeworkerWrapper(@NotNull Project project) {
         setUpToolWindowForConsoleViews(project);
     }
 
-    public EdgeworkerWrapper(){
+    public EdgeworkerWrapper() {
         resourceBundle = ResourceBundle.getBundle("ActionBundle");
     }
 
-    private void setUpToolWindowForConsoleViews(@NotNull Project project){
+    private void setUpToolWindowForConsoleViews(@NotNull Project project) {
         //create tool window
         this.project = project;
         toolWindowManager = ToolWindowManager.getInstance(project);
         resourceBundle = ResourceBundle.getBundle("ActionBundle");
         toolWindow = toolWindowManager.getToolWindow(resourceBundle.getString("toolwindow.id"));
-        if(null == toolWindow){
+        if (null == toolWindow) {
             RegisterToolWindowTask registerToolWindowTask = new RegisterToolWindowTask(resourceBundle.getString("toolwindow.id"), ToolWindowAnchor.BOTTOM, null, false,
                     true, true, true, null, null, null);
             toolWindow = toolWindowManager.registerToolWindow(registerToolWindowTask);
@@ -69,14 +74,14 @@ public class EdgeworkerWrapper implements Disposable {
         }
     }
 
-    public ConsoleView createConsoleViewOnNewTabOfToolWindow(String title, String description){
+    public ConsoleView createConsoleViewOnNewTabOfToolWindow(String title, String description) {
         //create console tab inside tool window
         ContentManager contentManager = toolWindow.getContentManager();
         ContentFactory contentFactory = contentManager.getFactory();
         TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(project);
         console = consoleBuilder.getConsole();
         console.clear();
-        console.print("----------------"+description+"----------------" + "\n", ConsoleViewContentType.LOG_INFO_OUTPUT);
+        console.print("----------------" + description + "----------------" + "\n", ConsoleViewContentType.LOG_INFO_OUTPUT);
         JComponent consolePanel = createConsolePanel(console);
         Content content = contentFactory.createContent(consolePanel, title, false);
         content.setDisposer(this::dispose);
@@ -88,7 +93,7 @@ public class EdgeworkerWrapper implements Disposable {
 
     public String runCommandsInConsoleView(ConsoleView console, ArrayList<GeneralCommandLine> commandLines) throws ExecutionException {
         StringBuilder errorMsg = new StringBuilder();
-        for(GeneralCommandLine cmdLine: commandLines){
+        for (GeneralCommandLine cmdLine : commandLines) {
             ProcessHandler processHandler = new OSProcessHandler(cmdLine);
             processHandler.addProcessListener(new ProcessListener() {
 
@@ -104,10 +109,9 @@ public class EdgeworkerWrapper implements Disposable {
 
                 @Override
                 public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
-                    if(!outputType.toString().equals("stderr")){
+                    if (!outputType.toString().equals("stderr")) {
                         console.print(event.getText(), ConsoleViewContentType.NORMAL_OUTPUT);
-                    }
-                    else if(!event.getText().contains("\u001b[1G") && !event.getText().contains("\u001b[2K")){
+                    } else if (!event.getText().contains("\u001b[1G") && !event.getText().contains("\u001b[2K")) {
                         console.print(event.getText(), ConsoleViewContentType.ERROR_OUTPUT);
                         errorMsg.append(event.getText());
                     }
@@ -119,29 +123,29 @@ public class EdgeworkerWrapper implements Disposable {
         return errorMsg.toString();
     }
 
-    public GeneralCommandLine getEdgeWorkerVersionListCommand(String eid, String tempFile) throws Exception{
+    public GeneralCommandLine getEdgeWorkerVersionListCommand(String eid, String tempFile) throws Exception {
         ArrayList<String> listEdgeWorkerVersionsCmd = new ArrayList<>();
         listEdgeWorkerVersionsCmd.addAll(Arrays.asList("akamai", "edgeworkers", "list-versions", eid, "--json", tempFile));
         listEdgeWorkerVersionsCmd = addOptionsParams(listEdgeWorkerVersionsCmd);
         GeneralCommandLine listEdgeWorkersCommandLine = new GeneralCommandLine(listEdgeWorkerVersionsCmd);
-        listEdgeWorkersCommandLine.setCharset(Charset.forName("UTF-8"));
+        listEdgeWorkersCommandLine.setCharset(StandardCharsets.UTF_8);
         return listEdgeWorkersCommandLine;
     }
 
-    public ArrayList<Map<String, String>> getEdgeWorkerVersionsList(String eid) throws Exception{
-        File tempFile = FileUtil.createTempFile("tempEdgeWorkerVersions",".json");
+    public ArrayList<Map<String, String>> getEdgeWorkerVersionsList(String eid) throws Exception {
+        File tempFile = FileUtil.createTempFile("tempEdgeWorkerVersions", ".json");
         GeneralCommandLine listEdgeWorkerVersionsCmd = getEdgeWorkerVersionListCommand(eid, tempFile.getPath());
         Integer exitCode = executeCommand(listEdgeWorkerVersionsCmd);
         return parseEdgeWorkersTempFile("list-versions", tempFile);
     }
 
-    public String executeCommandAndGetOutput(GeneralCommandLine commandLine) throws Exception{
+    public String executeCommandAndGetOutput(GeneralCommandLine commandLine) throws Exception {
         String output = ExecUtil.execAndGetOutput(commandLine, "");
         System.out.println(commandLine);
         return output;
     }
 
-    public Integer executeCommand(GeneralCommandLine commandLine) throws Exception{
+    public Integer executeCommand(GeneralCommandLine commandLine) throws Exception {
         ProcessHandler processHandler = new OSProcessHandler.Silent(commandLine);
         processHandler.startNotify();
         processHandler.waitFor();
@@ -149,159 +153,174 @@ public class EdgeworkerWrapper implements Disposable {
         return processHandler.getExitCode();
     }
 
-    public ArrayList<Map<String, String>> parseEdgeWorkersTempFile(String commandType, File tempFile){
+    public ArrayList<Map<String, String>> parseEdgeWorkersTempFile(String commandType, File tempFile) {
         ArrayList<Map<String, String>> result = new ArrayList<>();
         try {
             Gson gson = new Gson();
             Reader reader = Files.newBufferedReader(Paths.get(tempFile.getPath()));
             Map<?, ?> map = gson.fromJson(reader, Map.class);
-            if(null==map || null==map.get("cliStatus") || null==map.get("msg") || map.get("msg").toString().isEmpty()){
+            if (null == map || null == map.get("cliStatus") || null == map.get("msg") || map.get("msg").toString().isEmpty()) {
                 EdgeWorkerNotification.notifyError(null, "Error: Not Authorized.");
             }
-            if(map.get("cliStatus").equals(0.0)){
-                ArrayList<LinkedTreeMap> treeMapList = (ArrayList<LinkedTreeMap>) map.get("data");
-                if(commandType=="list-ids"){
-                    for(LinkedTreeMap treeMap: treeMapList){
-                        if(!treeMap.isEmpty()){
-                            Map<String, String> dataMap = new HashMap<>();
-                            Double edgeWorkerId = (Double)treeMap.get("edgeWorkerId");
-                            dataMap.put("edgeWorkerId", String.valueOf(Double.valueOf(edgeWorkerId).intValue()));
-                            dataMap.put("name", (String)treeMap.get("name"));
-                            result.add(dataMap);
-                        }
-                    }
-                }else if(commandType=="list-versions"){
-                    for(LinkedTreeMap treeMap: (ArrayList<LinkedTreeMap>) map.get("data")){
+            if (map.get("cliStatus").equals(0.0)) {
+                if (map.get("data").toString().equals("{}")) {
+                    // data is an empty object, cannot cast to ArrayList<LinkedTreeMap>
+                    if (commandType.equals("auth")) {
                         Map<String, String> dataMap = new HashMap<>();
-                        if(!treeMap.isEmpty()){
-                            dataMap.put("version", (String)treeMap.get("version"));
-                            result.add(dataMap);
-                        }
+                        dataMap.put("msg", (String) map.get("msg"));
+                        result.add(dataMap);
                     }
-                    System.out.println(result);
-                }else if(commandType=="status"){
-                    boolean staging = false;
-                    boolean prod = false;
-                    for(LinkedTreeMap treeMap: (ArrayList<LinkedTreeMap>) map.get("data")){
-                        Map<String, String> dataMap = new HashMap<>();
-                        if(!treeMap.isEmpty() && treeMap.get("status").equals("COMPLETE")){
-                            if(staging==false && treeMap.get("network").equals("STAGING")){
-                                //first record in json response for staging is the active version
-                                staging=true;
-                            }else if(prod==false && treeMap.get("network").equals("PRODUCTION")){
-                                //first record in json response for prod is the active version
-                                prod=true;
-                            }else{
-                                continue;
+                } else {
+                    ArrayList<LinkedTreeMap> treeMapList = (ArrayList<LinkedTreeMap>) map.get("data");
+                    switch (commandType) {
+                        case "list-ids":
+                            for (LinkedTreeMap treeMap : treeMapList) {
+                                if (!treeMap.isEmpty()) {
+                                    Map<String, String> dataMap = new HashMap<>();
+                                    Double edgeWorkerId = (Double) treeMap.get("edgeWorkerId");
+                                    dataMap.put("edgeWorkerId", String.valueOf(edgeWorkerId.intValue()));
+                                    dataMap.put("name", (String) treeMap.get("name"));
+                                    result.add(dataMap);
+                                }
                             }
-                            dataMap.put("network", (String)treeMap.get("network"));
-                            dataMap.put("version", (String)treeMap.get("version"));
-                            dataMap.put("activationId", String.valueOf(treeMap.get("activationId")));
-                            result.add(dataMap);
-                        }
-                    }
-                }else if(commandType=="list-groups"){
-                    for(LinkedTreeMap treeMap: (ArrayList<LinkedTreeMap>) map.get("data")){
-                        Map<String, String> dataMap = new HashMap<>();
-                        if(!treeMap.isEmpty()){
-                            Double groupId = (Double)treeMap.get("groupId");
-                            dataMap.put("groupId", String.valueOf(Double.valueOf(groupId).intValue()));
-                            dataMap.put("groupName", (String)treeMap.get("groupName"));
-                            result.add(dataMap);
-                        }
-                    }
-                }else if(commandType=="list-contracts"){
-                    for(LinkedTreeMap treeMap: (ArrayList<LinkedTreeMap>) map.get("data")){
-                        Map<String, String> dataMap = new HashMap<>();
-                        if(!treeMap.isEmpty()){
-                            dataMap.put("ContractIds", (String)treeMap.get("ContractIds"));
-                            result.add(dataMap);
-                        }
+                            break;
+                        case "list-versions":
+                            for (LinkedTreeMap treeMap : (ArrayList<LinkedTreeMap>) map.get("data")) {
+                                Map<String, String> dataMap = new HashMap<>();
+                                if (!treeMap.isEmpty()) {
+                                    dataMap.put("version", (String) treeMap.get("version"));
+                                    result.add(dataMap);
+                                }
+                            }
+                            System.out.println(result);
+                            break;
+                        case "status":
+                            boolean staging = false;
+                            boolean prod = false;
+                            for (LinkedTreeMap treeMap : (ArrayList<LinkedTreeMap>) map.get("data")) {
+                                Map<String, String> dataMap = new HashMap<>();
+                                if (!treeMap.isEmpty() && treeMap.get("status").equals("COMPLETE")) {
+                                    if (!staging && treeMap.get("network").equals("STAGING")) {
+                                        //first record in json response for staging is the active version
+                                        staging = true;
+                                    } else if (!prod && treeMap.get("network").equals("PRODUCTION")) {
+                                        //first record in json response for prod is the active version
+                                        prod = true;
+                                    } else {
+                                        continue;
+                                    }
+                                    dataMap.put("network", (String) treeMap.get("network"));
+                                    dataMap.put("version", (String) treeMap.get("version"));
+                                    dataMap.put("activationId", String.valueOf(treeMap.get("activationId")));
+                                    result.add(dataMap);
+                                }
+                            }
+                            break;
+                        case "list-groups":
+                            for (LinkedTreeMap treeMap : (ArrayList<LinkedTreeMap>) map.get("data")) {
+                                Map<String, String> dataMap = new HashMap<>();
+                                if (!treeMap.isEmpty()) {
+                                    Double groupId = (Double) treeMap.get("groupId");
+                                    dataMap.put("groupId", String.valueOf(groupId.intValue()));
+                                    dataMap.put("groupName", (String) treeMap.get("groupName"));
+                                    result.add(dataMap);
+                                }
+                            }
+                            break;
+                        case "list-contracts":
+                            for (LinkedTreeMap treeMap : (ArrayList<LinkedTreeMap>) map.get("data")) {
+                                Map<String, String> dataMap = new HashMap<>();
+                                if (!treeMap.isEmpty()) {
+                                    dataMap.put("ContractIds", (String) treeMap.get("ContractIds"));
+                                    result.add(dataMap);
+                                }
+                            }
+                            break;
                     }
                 }
-            }else if(!map.get("msg").toString().isEmpty()){
+            } else if (!map.get("msg").toString().isEmpty()) {
                 EdgeWorkerNotification.notifyError(null, (String) map.get("msg"));
             }
             reader.close();
             tempFile.delete();
-        } catch(Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             EdgeWorkerNotification.notifyError(null, "Error in executing Akamai CLI command.");
         }
         return result;
     }
 
-    public GeneralCommandLine getEdgeWorkersIdsListCommand(String tempFilePath) throws Exception{
+    public GeneralCommandLine getEdgeWorkersIdsListCommand(String tempFilePath) throws Exception {
         ArrayList<String> listEdgeWorkersCmd = new ArrayList<>();
         listEdgeWorkersCmd.addAll(Arrays.asList("akamai", "edgeworkers", "list-ids", "--json", tempFilePath));
         listEdgeWorkersCmd = addOptionsParams(listEdgeWorkersCmd);
         GeneralCommandLine listEdgeWorkersCommandLine = new GeneralCommandLine(listEdgeWorkersCmd);
-        listEdgeWorkersCommandLine.setCharset(Charset.forName("UTF-8"));
+        listEdgeWorkersCommandLine.setCharset(StandardCharsets.UTF_8);
         return listEdgeWorkersCommandLine;
     }
 
-    public ArrayList<Map<String, String>> getEdgeWorkersIdsList() throws Exception{
-        File tempFile = FileUtil.createTempFile("tempEdgeWorkersIds",".json");
+    public ArrayList<Map<String, String>> getEdgeWorkersIdsList() throws Exception {
+        File tempFile = FileUtil.createTempFile("tempEdgeWorkersIds", ".json");
         GeneralCommandLine commandLine = getEdgeWorkersIdsListCommand(tempFile.getPath());
         Integer exitCode = executeCommand(commandLine);
         return parseEdgeWorkersTempFile("list-ids", tempFile);
     }
 
-    public GeneralCommandLine getActiveEdgeWorkerVersionsOnStagingAndProd(String eid, String tempFile){
+    public GeneralCommandLine getActiveEdgeWorkerVersionsOnStagingAndProd(String eid, String tempFile) {
         ArrayList<String> cmd = new ArrayList<>();
         cmd.addAll(Arrays.asList("akamai", "edgeworkers", "status", eid, "--json", tempFile));
         cmd = addOptionsParams(cmd);
         GeneralCommandLine commandLine = new GeneralCommandLine(cmd);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public ArrayList<Map<String, String>> getActiveEdgeWorkerVersionsOnStagingAndProd(String eid) throws Exception{
-        File tempFile = FileUtil.createTempFile("tempActiveEdgeWorkerVersions",".json");
+    public ArrayList<Map<String, String>> getActiveEdgeWorkerVersionsOnStagingAndProd(String eid) throws Exception {
+        File tempFile = FileUtil.createTempFile("tempActiveEdgeWorkerVersions", ".json");
         GeneralCommandLine commandLine = getActiveEdgeWorkerVersionsOnStagingAndProd(eid, tempFile.getPath());
         Integer exitCode = executeCommand(commandLine);
         return parseEdgeWorkersTempFile("status", tempFile);
     }
 
-    public GeneralCommandLine getCreateBundleCommand(@NotNull String workDirectory, @NotNull VirtualFile[] ew_files, @NotNull VirtualFile destinationFolder) throws Exception{
+    public GeneralCommandLine getCreateBundleCommand(@NotNull String workDirectory, @NotNull VirtualFile[] ew_files, @NotNull VirtualFile destinationFolder) throws Exception {
         // command for creating Edgeworker bundle
         ArrayList<String> createBundleCmd = new ArrayList<>();
-        createBundleCmd.addAll(Arrays.asList("tar", "-czvf", destinationFolder.getCanonicalPath()+"/"+resourceBundle.getString("action.createandvalidatebundle.filename")));
-        for(VirtualFile file: ew_files){
+        createBundleCmd.addAll(Arrays.asList("tar", "-czvf", destinationFolder.getCanonicalPath() + "/" + resourceBundle.getString("action.createandvalidatebundle.filename")));
+        for (VirtualFile file : ew_files) {
             createBundleCmd.add(file.getName());
         }
         GeneralCommandLine createBundleCommandLine = new GeneralCommandLine(createBundleCmd);
         createBundleCommandLine.setWorkDirectory(workDirectory);
-        createBundleCommandLine.setCharset(Charset.forName("UTF-8"));
+        createBundleCommandLine.setCharset(StandardCharsets.UTF_8);
         return createBundleCommandLine;
     }
 
-    public ArrayList<String> addOptionsParams(ArrayList<String> cmd){
+    public ArrayList<String> addOptionsParams(ArrayList<String> cmd) {
         EdgeWorkersConfig edgeWorkersConfig = SettingsService.getInstance().getState();
-        if(null != edgeWorkersConfig.getEdgercFilePath() && !edgeWorkersConfig.getEdgercFilePath().isEmpty()){
+        if (null != edgeWorkersConfig.getEdgercFilePath() && !edgeWorkersConfig.getEdgercFilePath().isEmpty()) {
             cmd.addAll(Arrays.asList("--edgerc", edgeWorkersConfig.getEdgercFilePath()));
         }
-        if(null != edgeWorkersConfig.getEdgercSectionName() && !edgeWorkersConfig.getEdgercSectionName().isEmpty()){
+        if (null != edgeWorkersConfig.getEdgercSectionName() && !edgeWorkersConfig.getEdgercSectionName().isEmpty()) {
             cmd.addAll(Arrays.asList("--section", edgeWorkersConfig.getEdgercSectionName()));
         }
-        if(null != edgeWorkersConfig.getAccountKey() && !edgeWorkersConfig.getAccountKey().isEmpty()){
+        if (null != edgeWorkersConfig.getAccountKey() && !edgeWorkersConfig.getAccountKey().isEmpty()) {
             cmd.addAll(Arrays.asList("--accountkey", edgeWorkersConfig.getAccountKey()));
         }
         return cmd;
     }
 
-    public GeneralCommandLine getValidateBundleCommand(@NotNull String workDirectory, @NotNull VirtualFile destinationFolder) throws Exception{
+    public GeneralCommandLine getValidateBundleCommand(@NotNull String workDirectory, @NotNull VirtualFile destinationFolder) throws Exception {
         // command for validating Edgeworker bundle
         ArrayList<String> validateBundleCmd = new ArrayList<>();
-        validateBundleCmd.addAll(Arrays.asList("akamai", "edgeworkers", "validate",destinationFolder.getCanonicalPath()+"/"+resourceBundle.getString("action.createandvalidatebundle.filename")));
+        validateBundleCmd.addAll(Arrays.asList("akamai", "edgeworkers", "validate", destinationFolder.getCanonicalPath() + "/" + resourceBundle.getString("action.createandvalidatebundle.filename")));
         validateBundleCmd = addOptionsParams(validateBundleCmd);
         GeneralCommandLine validateBundleCommandLine = new GeneralCommandLine(validateBundleCmd);
         validateBundleCommandLine.setWorkDirectory(workDirectory);
-        validateBundleCommandLine.setCharset(Charset.forName("UTF-8"));
+        validateBundleCommandLine.setCharset(StandardCharsets.UTF_8);
         return validateBundleCommandLine;
     }
 
-    public void createAndValidateBundle(@NotNull String workDirectory, @NotNull VirtualFile[] ew_files, @NotNull VirtualFile destinationFolder) throws Exception{
+    public void createAndValidateBundle(@NotNull String workDirectory, @NotNull VirtualFile[] ew_files, @NotNull VirtualFile destinationFolder) throws Exception {
         ArrayList<GeneralCommandLine> commandLines = new ArrayList<>();
         commandLines.add(getCreateBundleCommand(workDirectory, ew_files, destinationFolder));
         commandLines.add(getValidateBundleCommand(workDirectory, destinationFolder));
@@ -314,24 +333,24 @@ public class EdgeworkerWrapper implements Disposable {
                             ProgressManager.getInstance().getProgressIndicator().setText("Creating and Validating Bundle...");
                             runCommandsInConsoleView(consoleView, commandLines);
                         } catch (ExecutionException e) {
-                            System.out.println("Command Execution failed!"+ e);
+                            System.out.println("Command Execution failed!" + e);
                             Messages.showErrorDialog("EdgeWorker Bundle not created!", "Error");
                         }
                     }
-                },"", false, project);
+                }, "", false, project);
         VfsUtil.markDirtyAndRefresh(false, false, true, destinationFolder);
     }
 
-    public GeneralCommandLine getActivateEdgeWorkerCommand(String eid, String version, String network) throws Exception{
+    public GeneralCommandLine getActivateEdgeWorkerCommand(String eid, String version, String network) throws Exception {
         ArrayList<String> cmd = new ArrayList<>();
         cmd.addAll(Arrays.asList("akamai", "edgeworkers", "activate", eid, network, version));
         cmd = addOptionsParams(cmd);
         GeneralCommandLine commandLine = new GeneralCommandLine(cmd);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public void activateEdgeWorker(String eid, String version, String network) throws Exception{
+    public void activateEdgeWorker(String eid, String version, String network) throws Exception {
         ArrayList<GeneralCommandLine> commandLines = new ArrayList<>();
         commandLines.add(getActivateEdgeWorkerCommand(eid, version, network));
         ConsoleView consoleView = createConsoleViewOnNewTabOfToolWindow("Activate EdgeWorker", "Activate EdgeWorker");
@@ -348,22 +367,22 @@ public class EdgeworkerWrapper implements Disposable {
                         }
 
                     }
-                },"Activate EdgeWorker", false, null);
+                }, "Activate EdgeWorker", false, null);
     }
 
-    public GeneralCommandLine getRegisterEdgeWorkerCommand(String groupId, String edgeWorkerName, Integer resourceTierId) throws Exception{
+    public GeneralCommandLine getRegisterEdgeWorkerCommand(String groupId, String edgeWorkerName, Integer resourceTierId) throws Exception {
         ArrayList<String> cmd = new ArrayList<>();
         cmd.addAll(Arrays.asList("akamai", "edgeworkers", "register", groupId, edgeWorkerName));
-        if(null!=resourceTierId){
+        if (null != resourceTierId) {
             cmd.addAll(Arrays.asList("--resourceTierId", resourceTierId.toString()));
         }
         cmd = addOptionsParams(cmd);
         GeneralCommandLine commandLine = new GeneralCommandLine(cmd);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public void registerEdgeWorker(String groupId, String edgeWorkerName, Integer resourceTierId) throws Exception{
+    public void registerEdgeWorker(String groupId, String edgeWorkerName, Integer resourceTierId) throws Exception {
         ArrayList<GeneralCommandLine> commandLines = new ArrayList<>();
         commandLines.add(getRegisterEdgeWorkerCommand(groupId, edgeWorkerName, resourceTierId));
         ConsoleView consoleView = createConsoleViewOnNewTabOfToolWindow("Register EdgeWorker", "Register EdgeWorker");
@@ -380,36 +399,36 @@ public class EdgeworkerWrapper implements Disposable {
                         }
 
                     }
-                },"Register EdgeWorker", false, null);
+                }, "Register EdgeWorker", false, null);
     }
 
-    public GeneralCommandLine getGroupsListCommand(String tmpFile) throws Exception{
+    public GeneralCommandLine getGroupsListCommand(String tmpFile) throws Exception {
         ArrayList<String> cmd = new ArrayList<>();
         cmd.addAll(Arrays.asList("akamai", "edgeworkers", "list-groups", "--json", tmpFile));
         cmd = addOptionsParams(cmd);
         GeneralCommandLine commandLine = new GeneralCommandLine(cmd);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public ArrayList<Map<String, String>> getGroupsList() throws Exception{
-        File tempFile = FileUtil.createTempFile("tempGroupsList",".json");
+    public ArrayList<Map<String, String>> getGroupsList() throws Exception {
+        File tempFile = FileUtil.createTempFile("tempGroupsList", ".json");
         GeneralCommandLine commandLine = getGroupsListCommand(tempFile.getPath());
         Integer exitCode = executeCommand(commandLine);
         return parseEdgeWorkersTempFile("list-groups", tempFile);
     }
 
-    public GeneralCommandLine getContractIdsListCommand(String tmpFile) throws Exception{
+    public GeneralCommandLine getContractIdsListCommand(String tmpFile) throws Exception {
         ArrayList<String> cmd = new ArrayList<>();
         cmd.addAll(Arrays.asList("akamai", "edgeworkers", "list-contracts", "--json", tmpFile));
         cmd = addOptionsParams(cmd);
         GeneralCommandLine commandLine = new GeneralCommandLine(cmd);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public ArrayList<Map<String, String>> getContractIdsList() throws Exception{
-        File tempFile = FileUtil.createTempFile("tempContractIdsList",".json");
+    public ArrayList<Map<String, String>> getContractIdsList() throws Exception {
+        File tempFile = FileUtil.createTempFile("tempContractIdsList", ".json");
         GeneralCommandLine commandLine = getContractIdsListCommand(tempFile.getPath());
         Integer exitCode = executeCommand(commandLine);
         return parseEdgeWorkersTempFile("list-contracts", tempFile);
@@ -422,76 +441,76 @@ public class EdgeworkerWrapper implements Disposable {
         return panel;
     }
 
-    public GeneralCommandLine getUploadEdgeWorkerCommand(String eid, String bundlePath) throws Exception{
+    public GeneralCommandLine getUploadEdgeWorkerCommand(String eid, String bundlePath) throws Exception {
         ArrayList<String> uploadEdgeWorkerCmd = new ArrayList<>();
         uploadEdgeWorkerCmd.addAll(Arrays.asList("akamai", "edgeworkers", "upload", eid, "--bundle", bundlePath));
         uploadEdgeWorkerCmd = addOptionsParams(uploadEdgeWorkerCmd);
         GeneralCommandLine uploadEdgeWorkerCmdLine = new GeneralCommandLine(uploadEdgeWorkerCmd);
-        uploadEdgeWorkerCmdLine.setCharset(Charset.forName("UTF-8"));
+        uploadEdgeWorkerCmdLine.setCharset(StandardCharsets.UTF_8);
         return uploadEdgeWorkerCmdLine;
     }
 
-    public void uploadEdgeWorker(String eid, String bundlePath) throws Exception{
+    public void uploadEdgeWorker(String eid, String bundlePath) throws Exception {
         ArrayList<GeneralCommandLine> commandLines = new ArrayList<>();
         commandLines.add(getUploadEdgeWorkerCommand(eid, bundlePath));
         ConsoleView consoleView = createConsoleViewOnNewTabOfToolWindow("Upload EdgeWorker", "Upload EdgeWorker");
         ProgressManager.getInstance()
                 .runProcessWithProgressSynchronously(new Runnable() {
-                                                      @Override
-                                                      public void run() {
-                                                          try {
-                                                              ProgressManager.getInstance().getProgressIndicator().setText("Uploading...");
-                                                              runCommandsInConsoleView(consoleView, commandLines);
-                                                          } catch (ExecutionException e) {
-                                                              e.printStackTrace();
-                                                              Messages.showErrorDialog("EdgeWorker was not uploaded!", "Error");
-                                                          }
-                                                      }
-                                                  },"Upload EdgeWorker", false, project);
+                    @Override
+                    public void run() {
+                        try {
+                            ProgressManager.getInstance().getProgressIndicator().setText("Uploading...");
+                            runCommandsInConsoleView(consoleView, commandLines);
+                        } catch (ExecutionException e) {
+                            e.printStackTrace();
+                            Messages.showErrorDialog("EdgeWorker was not uploaded!", "Error");
+                        }
+                    }
+                }, "Upload EdgeWorker", false, project);
     }
 
-    public GeneralCommandLine getEdgeWorkerDownloadCommand(String eid, String versionId, String downloadPath) throws Exception{
+    public GeneralCommandLine getEdgeWorkerDownloadCommand(String eid, String versionId, String downloadPath) throws Exception {
         ArrayList<String> downloadEdgeWorkerCmd = new ArrayList<>();
         downloadEdgeWorkerCmd.addAll(Arrays.asList("akamai", "edgeworkers", "download-version", eid, versionId, "--downloadPath", downloadPath));
         downloadEdgeWorkerCmd = addOptionsParams(downloadEdgeWorkerCmd);
         GeneralCommandLine downloadEdgeWorkerCmdLine = new GeneralCommandLine(downloadEdgeWorkerCmd);
-        downloadEdgeWorkerCmdLine.setCharset(Charset.forName("UTF-8"));
+        downloadEdgeWorkerCmdLine.setCharset(StandardCharsets.UTF_8);
         return downloadEdgeWorkerCmdLine;
     }
 
-    public Integer downloadEdgeWorker(String eid, String versionId, String downloadPath) throws Exception{
+    public Integer downloadEdgeWorker(String eid, String versionId, String downloadPath) throws Exception {
         GeneralCommandLine commandLine = getEdgeWorkerDownloadCommand(eid, versionId, downloadPath);
         Integer exitCode = executeCommand(commandLine);
         return exitCode;
     }
 
-    public GeneralCommandLine getExtractTgzFileCommand(String tgzFilePath, String extractDirectory) throws Exception{
+    public GeneralCommandLine getExtractTgzFileCommand(String tgzFilePath, String extractDirectory) throws Exception {
         ArrayList<String> listEdgeWorkerVersionsCmd = new ArrayList<>();
         listEdgeWorkerVersionsCmd.addAll(Arrays.asList("tar", "-xvzf", tgzFilePath, "-C", extractDirectory));
         GeneralCommandLine commandLine = new GeneralCommandLine(listEdgeWorkerVersionsCmd);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public Integer extractTgzFile(String tgzFilePath, String extractDirectory) throws Exception{
+    public Integer extractTgzFile(String tgzFilePath, String extractDirectory) throws Exception {
         GeneralCommandLine commandLine = getExtractTgzFileCommand(tgzFilePath, extractDirectory);
         Integer exitCode = executeCommand(commandLine);
-        if(null == exitCode || !exitCode.equals(0)){
+        if (null == exitCode || !exitCode.equals(0)) {
             System.out.println(" extractTgzFile exitCode");
         }
         return exitCode;
     }
 
-    public GeneralCommandLine getUpdateEdgeWorkerToSandboxCommand(String eid, String bundlePath){
+    public GeneralCommandLine getUpdateEdgeWorkerToSandboxCommand(String eid, String bundlePath) {
         ArrayList<String> command = new ArrayList<>();
         command.addAll(Arrays.asList("akamai", "sandbox", "update-edgeworker", eid, bundlePath));
         command = addOptionsParams(command);
         GeneralCommandLine commandLine = new GeneralCommandLine(command);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public void updateEdgeWorkerToSandbox(String eid, String bundlePath) throws Exception{
+    public void updateEdgeWorkerToSandbox(String eid, String bundlePath) throws Exception {
         ArrayList<GeneralCommandLine> commandLines = new ArrayList<>();
         commandLines.add(getUpdateEdgeWorkerToSandboxCommand(eid, bundlePath));
         ConsoleView consoleView = createConsoleViewOnNewTabOfToolWindow("Update EdgeWorker to Sandbox", "Update EdgeWorker to the default sandbox.");
@@ -502,9 +521,9 @@ public class EdgeworkerWrapper implements Disposable {
                         try {
                             ProgressManager.getInstance().getProgressIndicator().setText("Updating...");
                             String errorMsg = runCommandsInConsoleView(consoleView, commandLines);
-                            if(errorMsg.isEmpty()){
+                            if (errorMsg.isEmpty()) {
                                 consoleView.print(resourceBundle.getString("sandbox.testing.info"), ConsoleViewContentType.LOG_INFO_OUTPUT);
-                            }else if(errorMsg.contains(resourceBundle.getString("sandbox.error.doesNotExist"))){
+                            } else if (errorMsg.contains(resourceBundle.getString("sandbox.error.doesNotExist"))) {
                                 consoleView.print(resourceBundle.getString("sandbox.setup.info.link"), ConsoleViewContentType.LOG_INFO_OUTPUT);
                             }
                         } catch (ExecutionException e) {
@@ -512,8 +531,24 @@ public class EdgeworkerWrapper implements Disposable {
                             showErrorDialog("EdgeWorker was not updated to the Sandbox!", "Error");
                         }
                     }
-                },"Update EdgeWorker to Sandbox", false, project);
+                }, "Update EdgeWorker to Sandbox", false, project);
     }
+
+    public GeneralCommandLine getEdgeWorkerAuthCommand(String hostname, String tempFile) {
+        ArrayList<String> edgeWorkersAuthCommand = new ArrayList<>(Arrays.asList("akamai", "edgeworkers", "auth", hostname, "--expiry", "120", "--json", tempFile));
+        edgeWorkersAuthCommand = addOptionsParams(edgeWorkersAuthCommand);
+        GeneralCommandLine edgeWorkersAuthCommandLine = new GeneralCommandLine(edgeWorkersAuthCommand);
+        edgeWorkersAuthCommandLine.setCharset(StandardCharsets.UTF_8);
+        return edgeWorkersAuthCommandLine;
+    }
+
+    public String getEdgeWorkersAuthString(String hostname) throws Exception {
+        File tempFile = FileUtil.createTempFile("tempEdgeWorkerAuth", ".json");
+        GeneralCommandLine edgeWorkerAuthCmd = getEdgeWorkerAuthCommand(hostname, tempFile.getPath());
+        int exitCode = executeCommand(edgeWorkerAuthCmd);
+        return parseEdgeWorkersTempFile("auth", tempFile).get(0).get("msg");
+    }
+
 
     // keeping this code from the spike to eventually re-use later
 //    public String getEdgeWorkerProfilingHtml(String url, String eventHandler) throws Exception {
@@ -547,15 +582,15 @@ public class EdgeworkerWrapper implements Disposable {
 //        return jsFile.toString();
 //    }
 
-    public GeneralCommandLine getCLICommandLineByParams(String ...params){
+    public GeneralCommandLine getCLICommandLineByParams(String... params) {
         ArrayList<String> command = new ArrayList<>();
         command.addAll(Arrays.asList(params));
         GeneralCommandLine commandLine = new GeneralCommandLine(command);
-        commandLine.setCharset(Charset.forName("UTF-8"));
+        commandLine.setCharset(StandardCharsets.UTF_8);
         return commandLine;
     }
 
-    public boolean checkIfAkamaiCliInstalled(){
+    public boolean checkIfAkamaiCliInstalled() {
         final boolean[] akamaiCliInstalled = {true};
         final boolean[] edgeWorkersCliInstalled = {true};
         final boolean[] sandboxCliInstalled = {true};
@@ -570,8 +605,8 @@ public class EdgeworkerWrapper implements Disposable {
                         //check if akamai cli is installed
                         String output = executeCommandAndGetOutput(getCLICommandLineByParams("akamai", "help"));
                         if (!output.contains("akamai")) {
-                            akamaiCliInstalled[0]=false;
-                        }else{
+                            akamaiCliInstalled[0] = false;
+                        } else {
                             //install Akamai EdgeWorker CLI if not already installed
                             if (!output.contains("edgeworkers")) {
                                 ProgressManager.getInstance().getProgressIndicator().setText("Installing Akamai EdgeWorkers CLI...");
@@ -590,64 +625,64 @@ public class EdgeworkerWrapper implements Disposable {
                             }
                             //check if .edgerc file exist
                             EdgeWorkersConfig config = SettingsService.getInstance().getState();
-                            if(null!=config && null!=config.getEdgercFilePath()){
+                            if (null != config && null != config.getEdgercFilePath()) {
                                 File file = new File(config.getEdgercFilePath());
-                                if(!file.exists()) {
+                                if (!file.exists()) {
                                     edgercFileExist[0] = false;
                                 }
                             }
                         }
                     } catch (Exception exception) {
-                        akamaiCliInstalled[0]=false;
+                        akamaiCliInstalled[0] = false;
                         exception.printStackTrace();
                     }
                 }
             }, "", false, project);
-            if(akamaiCliInstalled[0]==false){
+            if (!akamaiCliInstalled[0]) {
                 //when akamai cli is not installed
                 CheckAkamaiCLIDialog checkAkamaiCLIDialog = new CheckAkamaiCLIDialog();
                 checkAkamaiCLIDialog.show();
-            }
-            else if(edgeWorkersCliInstalled[0]==false){
+            } else if (!edgeWorkersCliInstalled[0]) {
                 showErrorDialog("Please install akamai edgeworkers cli", "Error");
-            }else if(sandboxCliInstalled[0]==false){
+            } else if (!sandboxCliInstalled[0]) {
                 showErrorDialog("Please install akamai sandbox cli", "Error");
-            }else if(edgercFileExist[0]==false){
+            } else if (!edgercFileExist[0]) {
                 showErrorDialog("Please create and setup .edgerc file and configure EdgeWorkers settings at IntelliJ IDEA > Preferences/Settings > EdgeWorkers Configuration", "Error");
             }
-        }catch (Exception exception){
+        } catch (Exception exception) {
             exception.printStackTrace();
         }
         return akamaiCliInstalled[0] && edgeWorkersCliInstalled[0] && sandboxCliInstalled[0] && edgercFileExist[0];
     }
 
-    private void suppressCliPrompts(){
-        try{
+    private void suppressCliPrompts() {
+        try {
             //check if akamai-cli/config file exist
             File home = new File(System.getProperty("user.home"));
-            File cliConfigFile = new File(Paths.get(home.getAbsolutePath(),"/.akamai-cli/config").toString());
-            if(cliConfigFile.exists()) {
+            File cliConfigFile = new File(Paths.get(home.getAbsolutePath(), "/.akamai-cli/config").toString());
+            if (cliConfigFile.exists()) {
                 String content = Files.readString(cliConfigFile.toPath(), StandardCharsets.US_ASCII);
-                if(content.contains("enable-cli-statistics = false") && content.contains("last-upgrade-check = ignore")){
+                if (content.contains("enable-cli-statistics = false") && content.contains("last-upgrade-check = ignore")) {
                     return;
                 }
                 StringBuilder newContent = new StringBuilder();
-                for(String line: content.split("\n")){
-                    if(line.contains("enable-cli-statistics") || line.contains("last-upgrade-check")){
+                for (String line : content.split("\n")) {
+                    if (line.contains("enable-cli-statistics") || line.contains("last-upgrade-check")) {
                         continue;
                     }
-                    newContent.append(line+"\n");
+                    newContent.append(line + "\n");
                 }
                 newContent.append("enable-cli-statistics = false\n");
                 newContent.append("last-upgrade-check = ignore\n");
                 //overwrite .akamai-cli/config file
-                Files.write(cliConfigFile.toPath(), newContent.toString().getBytes(StandardCharsets.UTF_8),StandardOpenOption.TRUNCATE_EXISTING);
+                Files.write(cliConfigFile.toPath(), newContent.toString().getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
             }
-        }catch (Exception exception){
+        } catch (Exception exception) {
             exception.printStackTrace();
         }
     }
-    public void showErrorDialog(String message, String title){
+
+    public void showErrorDialog(String message, String title) {
         Messages.showErrorDialog(message, title);
     }
 


### PR DESCRIPTION
### Features
When profiling an edgeworker we will automatically call the Akamai CLI to get enhanced debug headers to use when requesting profiling data. A cache has also been implemented to only generate tokens if they are expired. This makes subsequent requests against the same host very fast :)

### Diff in src/main/java/utils/EdgeworkerWrapper.java
IntelliJ auto formatted the wrapper so please forgive the large diff. The relevant changes are:
- the new if block to handle the new auth command on [line 166](https://github.com/akamai/edgeworkers-intellij/compare/feature/EW-14119...feature/EW-14120?expand=1#diff-afb0eae26bedbba58c98f85d3ab3931b3798c890d846a39f5072437df610b8ffR166)
- the 2 new functions to wrap the auth CLI command on [line 537](https://github.com/akamai/edgeworkers-intellij/compare/feature/EW-14119...feature/EW-14120?expand=1#diff-afb0eae26bedbba58c98f85d3ab3931b3798c890d846a39f5072437df610b8ffR537)
