### PR TITLE
EW-14121: Make profiling http request

### DIFF
--- a/src/main/java/actions/RunCodeProfilerAction.java
+++ b/src/main/java/actions/RunCodeProfilerAction.java
@@ -3,16 +3,31 @@ package actions;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.progress.ProgressManager;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import ui.CodeProfilerToolWindow;
 import ui.EdgeWorkerNotification;
 import utils.DnsService;
 import utils.EdgeworkerWrapper;
 
+import javax.net.ssl.HostnameVerifier;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Objects;
 
@@ -102,7 +117,6 @@ public class RunCodeProfilerAction extends AnAction {
                 cname = DnsService.getCNAME(hostname)[0];
             } catch (Exception exception) {
                 throw new Exception("Error: Unable to resolve CNAME for hostname: " + hostname);
-
             }
         }
 
@@ -124,15 +138,18 @@ public class RunCodeProfilerAction extends AnAction {
      *
      * @param edgeworkerWrapper wrapper instance to call CLI with
      * @param hostname          hostname to get headers for
-     * @return String[]: header name value pair
+     * @return String[]: header name value pair, or null if the header could not be generated
      * @throws Exception thrown if we cannot get the secure trace headers
      */
-    private String[] getSecureTraceHeader(EdgeworkerWrapper edgeworkerWrapper, String hostname) throws Exception {
+    private @Nullable String[] getSecureTraceHeader(EdgeworkerWrapper edgeworkerWrapper, String hostname) throws Exception {
         String[] secureTraceTokenHeader = getAuthCache(hostname);
         if (secureTraceTokenHeader != null) {
             return secureTraceTokenHeader;
         }
         String edgeWorkersAuthResponseString = edgeworkerWrapper.getEdgeWorkersAuthString(hostname);
+        if (edgeWorkersAuthResponseString == null) {
+            return null;
+        }
 
         // Separate header name and value since they are returned as a string by the API
         String secureTraceHeader;
@@ -142,7 +159,7 @@ public class RunCodeProfilerAction extends AnAction {
             secureTraceValue = edgeWorkersAuthResponseString.substring(edgeWorkersAuthResponseString.indexOf(": ") + 2);
         } catch (IndexOutOfBoundsException exception) {
             // this shouldn't ever really happen but is useful in the rare chance that it ever does
-            throw new Exception("Error: Unable to get enhanced debug headers: Invalid response");
+            throw new Exception("Error: Unable to get secure trace header: Invalid response");
         }
 
         // cache auth token
@@ -150,45 +167,173 @@ public class RunCodeProfilerAction extends AnAction {
         return new String[]{secureTraceHeader, secureTraceValue};
     }
 
+    private String callCodeProfiler(URI uri, InetAddress stagingIp, ArrayList<String[]> headers) throws Exception {
+        System.setProperty("javax.net.debug", "ssl:handshake");
+        HttpClient client;
+        HttpGet request;
+        HttpResponse response;
+        HttpEntity entity;
+        String jsonString = "";
+        String noEventHandler = "cannot generate code profile for requested event handler. Check EdgeWorker code bundle for implemented event handlers.";
+
+        try {
+            // Disable hostname verification since we won't be modifying the hosts file
+            // https://techdocs.akamai.com/api-acceleration/docs/test-stage
+            HostnameVerifier hv = NoopHostnameVerifier.INSTANCE;
+
+            // todo investigate SSL issues in EW-14599
+            // certificate validation doesn't seem to change anything
+            // Allow self-signed certs
+//            TrustStrategy ts = new TrustSelfSignedStrategy();
+//
+//            //Create sslSocketFactory
+//            SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+//            sslContextBuilder.loadTrustMaterial(null, ts);
+//            SSLConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(
+//                    sslContextBuilder.build(),
+//                    hv
+//            );
+
+            client = HttpClients.custom()
+                    .setSSLHostnameVerifier(hv)
+                    .build();
+
+            String stagingUri = uri.toString().replace(uri.getHost(), stagingIp.getHostAddress());
+            request = new HttpGet(new URI(stagingUri));
+            headers.forEach((x) -> request.addHeader(x[0], x[1]));
+
+            response = client.execute(request);
+
+            entity = response.getEntity();
+            String contentType;
+
+            if (entity == null || entity.getContentType() == null) {
+                // the response is empty
+                // this seems to happen when the edgeWorker runs into a limit while profiling
+                throw new Exception("EdgeWorker took too long to respond.");
+            } else {
+                contentType = entity.getContentType().getValue();
+            }
+
+            if (contentType.contains("application/json")) {
+                jsonString = EntityUtils.toString(entity);
+            } else if (contentType.contains("multipart/form-data")) {
+                // response provider event handler will return a multipart
+                String boundary = contentType.split("(;\\s+boundary=)")[1];
+                BufferedReader reader = new BufferedReader(new InputStreamReader(entity.getContent()));
+                StringBuilder sb = new StringBuilder();
+                String line;
+
+                while (reader.ready()) {
+                    line = reader.readLine();
+                    if (line.contains("content-disposition: form-data; name=\"cpu-profile\"")) {
+                        // the next line is the break between the header and body of the section, let's skip it
+                        reader.readLine();
+                        line = reader.readLine();
+
+                        while (!line.startsWith("--" + boundary) && reader.ready()) {
+                            // loop in the event that profile data is changed to a multi line response in the future
+                            sb.append(line).append(System.getProperty("line.separator"));
+                            line = reader.readLine();
+                        }
+                        break;
+                    }
+                }
+                jsonString = sb.toString();
+                reader.close();
+            } else if (contentType.contains("text/html")) {
+                // we are getting back the actual website, not the profiling results
+                throw new Exception(noEventHandler);
+            }
+
+            EntityUtils.consume(entity);
+
+            if (jsonString.startsWith("{\"nodes\"")) {
+                return jsonString;
+            } else {
+                throw new Exception(noEventHandler);
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            throw new Exception("Error: Unable to run profiler: " + exception.getMessage());
+        }
+    }
+
+    private String saveStringToFile(String pathname, String data) throws Exception {
+        try {
+            File file = new File(pathname);
+            if (file.createNewFile()) {
+                Files.writeString(file.toPath(), data);
+            } else {
+                Files.writeString(file.toPath(), data, StandardOpenOption.TRUNCATE_EXISTING);
+            }
+            return file.getAbsoluteFile().toString();
+        } catch (Exception exception) {
+            throw new Exception("Error: Cannot save file to " + pathname + " : " + exception.getMessage());
+        }
+    }
+
     /**
      * Creates a new thread and runs the various steps we need to get profiling data from the hostname.
      *
      * @param edgeworkerWrapper wrapper instance to call CLI with
      * @param event             event which triggered the action
-     * @param hostname          hostname to profile
+     * @param uri               uri to EdgeWorker
      * @param eventHandler      event handler to profile
      * @param filePath          profiling data directory
      * @param fileName          profiling data file name
      * @param headers           any additional headers to include in the http request
      */
-    private void profileEdgeWorker(EdgeworkerWrapper edgeworkerWrapper, AnActionEvent event, String hostname, String eventHandler, String filePath, String fileName, ArrayList<String[]> headers) {
+    private void profileEdgeWorker(EdgeworkerWrapper edgeworkerWrapper, AnActionEvent event, URI uri, String eventHandler, String filePath, String fileName, ArrayList<String[]> headers) {
         codeProfiler.setIsLoading(true);
         ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
             try {
                 // Get staging IP
                 ProgressManager.getInstance().getProgressIndicator().setText("Determining staging IP address...");
-                InetAddress stagingIp = getStagingIp(hostname);
+                InetAddress stagingIp = getStagingIp(uri.getHost());
 
                 // Get secure trace headers
-                ProgressManager.getInstance().getProgressIndicator().setText("Generating enhanced debug header...");
-                String[] secureTraceTokenHeader = getSecureTraceHeader(edgeworkerWrapper, hostname);
+                ProgressManager.getInstance().getProgressIndicator().setText("Generating secure trace header...");
+                String[] secureTraceTokenHeader = getSecureTraceHeader(edgeworkerWrapper, uri.getHost());
+                if (secureTraceTokenHeader == null) {
+                    // something went wrong in the wrapper when generating the header
+                    // the wrapper has already displayed an error notification explaining why
+                    return;
+                }
+
+                // Set headers
                 headers.add(secureTraceTokenHeader);
+                headers.add(new String[]{"x-ew-code-profile-" + eventHandler.toLowerCase(), "on"});
+                headers.add(new String[]{"user-agent", "EdgeWorkers IntelliJ Plugin"});
+
+                // Add Host header if not already set by the user
+                boolean hostExists = false;
+                for (String[] header : headers) {
+                    if (header[0].equals("Host")) {
+                        hostExists = true;
+                        break;
+                    }
+                }
+                if (!hostExists) {
+                    headers.add(new String[]{"Host", uri.getHost()});
+                }
 
                 // Make http call
-                //ProgressManager.getInstance().getProgressIndicator().setText("Getting profiling data...");
+                ProgressManager.getInstance().getProgressIndicator().setText("Getting profiling data...");
+                String jsonString = callCodeProfiler(uri, stagingIp, headers);
 
+                // Save json string to file
+                String dest = saveStringToFile(filePath + fileName + ".cpuprofile", jsonString);
+                EdgeWorkerNotification.notifyInfo(event.getProject(), "Successfully downloaded code profile to path: " + dest);
 
-                System.out.println(stagingIp.toString());
-                System.out.println(Arrays.toString(secureTraceTokenHeader));
-
-                // convert profile to html & js
+                // Convert profile to html & js
                 // String pathToHtml = edgeworkerWrapper.getEdgeWorkerProfilingHtml(edgeWorkerURL, eventHandler);
                 // bundling speedscope???
                 // render html
 
             } catch (Exception exception) {
                 EdgeWorkerNotification.notifyError(null,
-                        Objects.requireNonNullElse(exception.getMessage(), "Error: Unable to profile hostname: " + hostname));
+                        Objects.requireNonNullElse(exception.getMessage(), "Error: Unable to profile URL " + uri.toString()));
                 exception.printStackTrace();
             } finally {
                 codeProfiler.setIsLoading(false);
@@ -201,21 +346,27 @@ public class RunCodeProfilerAction extends AnAction {
         if (!new EdgeworkerWrapper().checkIfAkamaiCliInstalled()) {
             return;
         }
-        EdgeworkerWrapper edgeworkerWrapper = new EdgeworkerWrapper(e.getProject());
+        EdgeworkerWrapper edgeworkerWrapper = new EdgeworkerWrapper();
         String edgeWorkerURL = codeProfiler.getEdgeWorkerURL();
         String eventHandler = codeProfiler.getSelectedEventHandler();
+        URI uri;
         String filePath = codeProfiler.getFilePath();
         String fileName = codeProfiler.getFileName();
         ArrayList<String[]> headers = codeProfiler.getHeaders();
-        String hostname;
 
-        if (edgeWorkerURL.contains("://")) {
-            // remove protocol from hostname
-            hostname = edgeWorkerURL.split("(://)")[1];
-        } else {
-            hostname = edgeWorkerURL;
+        try {
+            uri = new URI(edgeWorkerURL);
+
+            // append trailing separator to path if it's missing
+            if (!filePath.endsWith(File.separator)) {
+                filePath = filePath + File.separator;
+            }
+
+            profileEdgeWorker(edgeworkerWrapper, e, uri, eventHandler, filePath, fileName, headers);
+        } catch (URISyntaxException ex) {
+            // this should never really happen because the UI will validate the input for us
+            EdgeWorkerNotification.notifyError(e.getProject(), "Error: EdgeWorker URL is an invalid URL");
         }
-        profileEdgeWorker(edgeworkerWrapper, e, hostname, eventHandler, filePath, fileName, headers);
     }
 
     static class HeaderCache {

--- a/src/main/java/ui/EdgeWorkerNotification.java
+++ b/src/main/java/ui/EdgeWorkerNotification.java
@@ -8,8 +8,14 @@ import org.jetbrains.annotations.Nullable;
 public class EdgeWorkerNotification {
 
     public static void notifyError(@Nullable Project project, String content) {
-        NotificationGroupManager.getInstance().getNotificationGroup("Custom Notification Group")
+        NotificationGroupManager.getInstance().getNotificationGroup("EdgeWorkers Notification Group")
                 .createNotification(content, NotificationType.ERROR)
+                .notify(project);
+    }
+
+    public static void notifyInfo(@Nullable Project project, String content) {
+        NotificationGroupManager.getInstance().getNotificationGroup("EdgeWorkers Notification Group")
+                .createNotification(content, NotificationType.INFORMATION)
                 .notify(project);
     }
 

--- a/src/main/java/utils/EdgeworkerWrapper.java
+++ b/src/main/java/utils/EdgeworkerWrapper.java
@@ -546,7 +546,13 @@ public class EdgeworkerWrapper implements Disposable {
         File tempFile = FileUtil.createTempFile("tempEdgeWorkerAuth", ".json");
         GeneralCommandLine edgeWorkerAuthCmd = getEdgeWorkerAuthCommand(hostname, tempFile.getPath());
         int exitCode = executeCommand(edgeWorkerAuthCmd);
-        return parseEdgeWorkersTempFile("auth", tempFile).get(0).get("msg");
+        ArrayList<Map<String, String>> result = parseEdgeWorkersTempFile("auth", tempFile);
+        if (result.size() == 0) {
+            // parseEdgeWorkersTempFile has already displayed a notification with the error message, just return null
+            return null;
+        } else {
+            return result.get(0).get("msg");
+        }
     }
 
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,9 @@
 <idea-plugin>
     <id>com.akamai.edgeworkers-intellij</id>
     <name>EdgeWorkers Toolkit</name>
-    <vendor email="devrel-edgeworkers@akamai.com" url="https://developer.akamai.com/developer-tools">AkamaiTechnologies</vendor>
+    <vendor email="devrel-edgeworkers@akamai.com" url="https://developer.akamai.com/developer-tools">
+        AkamaiTechnologies
+    </vendor>
 
     <description><![CDATA[
     <h1>Akamai EdgeWorkers IntelliJ Plugin</h1>
@@ -31,8 +33,9 @@
         <applicationService serviceImplementation="config.SettingsService"/>
         <toolWindow factoryClass="ui.ListEdgeWorkersToolWindowFactory" id="EdgeWorkers Explorer" anchor="left"
                     secondary="true"/>
-        <toolWindow factoryClass="ui.CodeProfilerToolWindowFactory" id="EdgeWorkers Code Profiler" anchor="bottom" icon="AllIcons.Actions.ProfileCPU"/>
-        <notificationGroup id="Custom Notification Group" displayType="BALLOON" />
+        <toolWindow factoryClass="ui.CodeProfilerToolWindowFactory" id="EdgeWorkers Code Profiler" anchor="bottom"
+                    icon="AllIcons.Actions.ProfileCPU"/>
+        <notificationGroup id="EdgeWorkers Notification Group" displayType="BALLOON"/>
     </extensions>
 
     <actions>
@@ -43,8 +46,8 @@
         -->
         <group id="EdgeworkersActionGroup" class="EdgeworkersActionGroup"
                popup="true" text="Akamai EdgeWorkers" description="Akamai EdgeWorkers">
-            <add-to-group group-id="ProjectViewPopupMenu" anchor="first" />
-            <add-to-group group-id="EditorPopupMenu" anchor="first" />
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
+            <add-to-group group-id="EditorPopupMenu" anchor="first"/>
         </group>
 
     </actions>


### PR DESCRIPTION
This PR makes the http(s) request to actually get the profiling information from the desired edgeworker.
The validation in the UI and some error handling has also been improved.

Note that there seems to be some sort of issue with the bundled Apache HttpClient and some kind of SSL exception that only occurs when profiling certain edgeworkers. This will be addressed in EW-14599.