### PR TITLE
EW-14851: Implement memory profiling

### DIFF
--- a/src/main/java/ui/CodeProfilerToolWindow.java
+++ b/src/main/java/ui/CodeProfilerToolWindow.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.ui.playback.commands.ActionCommand;
 import com.intellij.ui.CollapsiblePanel;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBRadioButton;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
 import utils.Constants;
@@ -29,6 +30,8 @@ public class CodeProfilerToolWindow {
 
     private final ResourceBundle resourceBundle;
     private final SimpleToolWindowPanel panel;
+    private JBRadioButton cpuButton;
+    private JBRadioButton memoryButton;
     private JBHintTextField edgeWorkerURLValue;
     private ComboBox<String> eventHandlerDropdown;
     private ComboBox<String> methodDropdown;
@@ -57,6 +60,10 @@ public class CodeProfilerToolWindow {
             actionManager.unregisterAction(resourceBundle.getString("action.runCodeProfiler.id"));
         }
         actionManager.registerAction(resourceBundle.getString("action.runCodeProfiler.id"), new RunCodeProfilerAction(this));
+    }
+
+    public String getProfilingMode() {
+        return cpuButton.isSelected() ? Constants.CPU_PROFILING : Constants.MEM_PROFILING;
     }
 
     public String getSelectedEventHandler() {
@@ -318,6 +325,17 @@ public class CodeProfilerToolWindow {
         edgeIpOverride = new JBHintTextField("Enter edge server IP address", 18);
         defaultBorder = edgeWorkerURLValue.getBorder();
 
+        // Radio Group
+        cpuButton = new JBRadioButton("CPU Profiling");
+        memoryButton = new JBRadioButton("Memory Profiling");
+        cpuButton.setSelected(true);
+        JPanel modeButtons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        modeButtons.add(cpuButton);
+        modeButtons.add(memoryButton);
+        ButtonGroup radioGroup = new ButtonGroup();
+        radioGroup.add(cpuButton);
+        radioGroup.add(memoryButton);
+
         // Error Labels
         edgeWorkerURLValueErrorLabel = new JBLabel("The EdgeWorker URL must be a valid URL");
         edgeWorkerURLValueErrorLabel.setVisible(false);
@@ -344,6 +362,12 @@ public class CodeProfilerToolWindow {
         layout.setAutoCreateContainerGaps(true);
 
         // Sub Panels
+        // Top Row Panel
+        JPanel topRow = new JPanel(new BorderLayout());
+        topRow.setMaximumSize(new Dimension(Integer.MAX_VALUE, cpuButton.getPreferredSize().height));
+        topRow.add(stagingLabel, BorderLayout.WEST);
+        topRow.add(modeButtons, BorderLayout.EAST);
+
         // URL + Method Panel
         JPanel urlMethodPanel = new JPanel(new BorderLayout());
         urlMethodPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, methodDropdown.getPreferredSize().height));
@@ -406,7 +430,7 @@ public class CodeProfilerToolWindow {
                         .addComponent(edgeIpOverride)
                 )
         );
-        CollapsiblePanel collapsibleAdvanced = new CollapsiblePanel(advancedPanel, true, true, AllIcons.Actions.Collapseall, AllIcons.Actions.Expandall, "Advanced");
+        CollapsiblePanel collapsibleAdvanced = new CollapsiblePanel(advancedPanel, true, true, AllIcons.Actions.Collapseall, AllIcons.Actions.Expandall, "");
 
         //      Panel For the whole row
         JPanel bottomRow = new JPanel(new BorderLayout());
@@ -419,7 +443,7 @@ public class CodeProfilerToolWindow {
 
         // Layout Components
         layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
-                .addComponent(stagingLabel, GroupLayout.Alignment.LEADING)
+                .addComponent(topRow, GroupLayout.Alignment.LEADING)
                 .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                                 .addComponent(ewNameLabel)
@@ -444,7 +468,7 @@ public class CodeProfilerToolWindow {
         );
 
         layout.setVerticalGroup(layout.createSequentialGroup()
-                .addComponent(stagingLabel)
+                .addComponent(topRow)
                 .addGroup(layout.createParallelGroup(GroupLayout.Alignment.CENTER)
                         .addComponent(ewNameLabel)
                         .addComponent(urlMethodPanel)

--- a/src/main/java/utils/Constants.java
+++ b/src/main/java/utils/Constants.java
@@ -1,9 +1,12 @@
 package utils;
 
 public final class Constants {
+    public static final String CPU_PROFILING = "CPU_PROFILING";
+    public static final String MEM_PROFILING = "MEM_PROFILING";
     public static final String[] EW_HTTP_METHODS = new String[]{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"};
     public static final String EW_DEFAULT_SAMPLING_SIZE = "5";
     public static final String EW_SAMPLING_HEADER = "x-ew-code-profile-cpu-sampling-interval";
+    public static final String EW_MEM_PROFILING_HEADER = "x-ew-code-profile-memory";
     public static final String EW_USER_AGENT = "EdgeWorkers IntelliJ Plugin";
     public static final String CONVERTED_FILE_NAME = "convertedCpuProfile";
     public static final int SPEEDSCOPE_NUMBER_OF_FILES = 16;


### PR DESCRIPTION
This PR adds a radio group to select between CPU or memory profiling.
Heapprofile files will then be displayed using the existing speedscope solution.

Some minor changes include some small improvements to the staging IP override and the removal of the advanced title for a cleaner UI.

![image](https://user-images.githubusercontent.com/33794710/209200553-3c6df8a4-304b-41b1-9f17-f846099f1d65.png)