### PR TITLE
Add in retry logic for memory profiling

### DIFF
--- a/src/main/java/utils/Constants.java
+++ b/src/main/java/utils/Constants.java
@@ -8,7 +8,7 @@ public final class Constants {
     public static final String EW_SAMPLING_HEADER = "x-ew-code-profile-cpu-sampling-interval";
     public static final String EW_MEM_PROFILING_HEADER = "x-ew-code-profile-memory";
     public static final String EW_USER_AGENT = "EdgeWorkers IntelliJ Plugin";
-    public static final String CONVERTED_FILE_NAME = "convertedCpuProfile";
+    public static final String CONVERTED_FILE_NAME = "convertedProfile";
     public static final int SPEEDSCOPE_NUMBER_OF_FILES = 16;
     public static String JAVA_TMP_URL = createJavaTmpURL();
 

--- a/src/main/java/utils/EdgeworkerWrapper.java
+++ b/src/main/java/utils/EdgeworkerWrapper.java
@@ -47,6 +47,8 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 public class EdgeworkerWrapper implements Disposable {
 
+    private String MIN_SUPPORTED_CLI_VER = "1.7.0";
+
     private ToolWindowManager toolWindowManager;
     private ToolWindow toolWindow;
     private Project project;
@@ -645,7 +647,12 @@ public class EdgeworkerWrapper implements Disposable {
         // do the attempt once per process init using the static variable above
         if (!updateAttempted) {
             try {
-                executeCommandAndGetOutput(getCLICommandLineByParams("akamai", "update", "edgeworkers"));
+                String version = executeCommandAndGetOutput(getCLICommandLineByParams("akamai", "edgeworkers", "--version")).trim();
+
+                // if less than where we want to be
+                if (version.compareTo(MIN_SUPPORTED_CLI_VER) < 0) {
+                    executeCommandAndGetOutput(getCLICommandLineByParams("akamai", "update", "edgeworkers"));
+                }
             } catch (Exception exception) {
                 // the above command failing is non critical so we won't do anything on failure
                 // just catch the error to prevent it from causing problems for extension use


### PR DESCRIPTION
A bug sometimes causes memory profiling to come back blank. This doesn't happen all the time but is usually resolved by retrying the request. This PR adds in retry logic to attempt again, and if the retries don't help displays an error instead of a blank result