### PR TITLE
Bug/EW-25318

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.akamai.edgeworkers'
-version '2.3.0'
+version '2.4.0'
 
 repositories {
     mavenCentral()
@@ -45,6 +45,7 @@ publishPlugin {
 runIde {
     jbrVersion = '17.0.7-b1000.2' // JBR for 2023.2
     // See https://github.com/JetBrains/JetBrainsRuntime#releases-based-on-jdk-17
+    autoReloadPlugins = true
 }
 
 verifyPluginConfiguration {

--- a/src/main/java/EdgeworkersActionGroup.java
+++ b/src/main/java/EdgeworkersActionGroup.java
@@ -1,8 +1,6 @@
 import actions.*;
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.actionSystem.ActionGroup;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import java.util.ResourceBundle;
@@ -19,5 +17,10 @@ public class EdgeworkersActionGroup extends ActionGroup {
                 new ActivateEdgeWorkerAction(resourceBundle.getString("action.activateEdgeWorker.title"), resourceBundle.getString("action.activateEdgeWorker.desc"), AllIcons.Actions.Install),
                 new RegisterEdgeWorkerAction(resourceBundle.getString("action.registerEdgeWorker.title"), resourceBundle.getString("action.registerEdgeWorker.desc"), AllIcons.Actions.RefactoringBulb),
         };
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 }

--- a/src/main/java/actions/ActivateEdgeWorkerAction.java
+++ b/src/main/java/actions/ActivateEdgeWorkerAction.java
@@ -1,7 +1,6 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.ui.Messages;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -90,4 +89,10 @@ public class ActivateEdgeWorkerAction extends AnAction {
             ex.printStackTrace();
         }
     }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
 }

--- a/src/main/java/actions/CreateAndValidateBundleAction.java
+++ b/src/main/java/actions/CreateAndValidateBundleAction.java
@@ -1,8 +1,6 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -68,4 +66,10 @@ public class CreateAndValidateBundleAction extends AnAction {
     public CreateAndValidateBundleUI getCreateAndValidateBundleUI(){
         return new CreateAndValidateBundleUI();
     }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
 }

--- a/src/main/java/actions/DownloadEdgeWorkerAction.java
+++ b/src/main/java/actions/DownloadEdgeWorkerAction.java
@@ -1,7 +1,6 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.fileChooser.FileChooser;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
@@ -110,4 +109,10 @@ public class DownloadEdgeWorkerAction extends AnAction {
     public void notifyError(AnActionEvent event, String content){
         EdgeWorkerNotification.notifyError(event.getProject(), content);
     }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
 }

--- a/src/main/java/actions/ListEdgeWorkersAction.java
+++ b/src/main/java/actions/ListEdgeWorkersAction.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.AnimatedIcon;
 import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.EditorTextField;
-import com.intellij.ui.TreeSpeedSearch;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.Tree;
 import org.jetbrains.annotations.NotNull;
@@ -103,7 +102,6 @@ public class ListEdgeWorkersAction extends AnAction {
                         rootNode.add(node);
                     }
 
-                    addTreeSpeedSearch(tree);
                     addColoredTreeCellRenderer(tree);
                     addTreeWillExpandListener(tree, edgeworkerWrapper, e);
 
@@ -126,10 +124,6 @@ public class ListEdgeWorkersAction extends AnAction {
                 }
             }
         }, "EdgeWorkers List", false, e.getProject());
-    }
-
-    private void addTreeSpeedSearch(Tree tree){
-        TreeSpeedSearch treeSpeedSearch = new TreeSpeedSearch(tree);
     }
 
     private void addColoredTreeCellRenderer(Tree tree){

--- a/src/main/java/actions/ListEdgeWorkersAction.java
+++ b/src/main/java/actions/ListEdgeWorkersAction.java
@@ -293,6 +293,11 @@ public class ListEdgeWorkersAction extends AnAction {
         }
     }
 
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
     public SimpleToolWindowPanel getPanel() {
         return panel;
     }

--- a/src/main/java/actions/RegisterEdgeWorkerAction.java
+++ b/src/main/java/actions/RegisterEdgeWorkerAction.java
@@ -1,7 +1,6 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.ui.Messages;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -60,6 +59,11 @@ public class RegisterEdgeWorkerAction extends AnAction {
         }catch (Exception ex){
             ex.printStackTrace();
         }
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
 }

--- a/src/main/java/actions/RunCodeProfilerAction.java
+++ b/src/main/java/actions/RunCodeProfilerAction.java
@@ -1,7 +1,6 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.progress.ProgressManager;
@@ -557,6 +556,11 @@ public class RunCodeProfilerAction extends AnAction {
         } catch (UnknownHostException ex) {
             EdgeWorkerNotification.notifyError(e.getProject(), "Error: Edge IP override is not a valid IP address");
         }
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     static class HeaderCache {

--- a/src/main/java/actions/SandboxUpdateEdgeWorkerAction.java
+++ b/src/main/java/actions/SandboxUpdateEdgeWorkerAction.java
@@ -1,8 +1,6 @@
 package actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
@@ -18,6 +16,11 @@ public class SandboxUpdateEdgeWorkerAction extends AnAction {
     public void update(@NotNull AnActionEvent event) {
         PsiFile psiFile =  event.getData(CommonDataKeys.PSI_FILE);
         event.getPresentation().setEnabledAndVisible(null != event.getProject() && null != psiFile && psiFile.getName().endsWith(".tgz"));
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
     }
 
     public SandboxUpdateEdgeWorkerAction(@Nullable String text, @Nullable String description, @Nullable Icon icon) {

--- a/src/main/java/actions/UploadEdgeWorkerAction.java
+++ b/src/main/java/actions/UploadEdgeWorkerAction.java
@@ -150,4 +150,10 @@ public class UploadEdgeWorkerAction extends AnAction {
     public void showErrorDialog(String message, String title){
         Messages.showErrorDialog(message, title);
     }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
 }

--- a/src/main/java/config/SettingsService.java
+++ b/src/main/java/config/SettingsService.java
@@ -1,6 +1,7 @@
 package config;
 
 import com.intellij.openapi.components.*;
+import com.intellij.openapi.application.*;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,7 +15,8 @@ public class SettingsService implements PersistentStateComponent<EdgeWorkersConf
     private EdgeWorkersConfig config = new EdgeWorkersConfig();
 
     public static SettingsService getInstance() {
-        return ServiceManager.getService(SettingsService.class);
+        return ApplicationManager.getApplication()
+                .getService(SettingsService.class);
     }
 
     @Override

--- a/src/main/java/ui/ListEdgeWorkersToolWindowFactory.java
+++ b/src/main/java/ui/ListEdgeWorkersToolWindowFactory.java
@@ -11,11 +11,6 @@ import org.jetbrains.annotations.NotNull;
 public class ListEdgeWorkersToolWindowFactory implements ToolWindowFactory {
 
     @Override
-    public boolean isApplicable(@NotNull Project project) {
-        return ToolWindowFactory.super.isApplicable(project);
-    }
-
-    @Override
     public boolean shouldBeAvailable(@NotNull Project project) {
         return ToolWindowFactory.super.shouldBeAvailable(project);
     }


### PR DESCRIPTION
Worked on below action items

- ActionUpdateThread.OLD_EDT is deprecated EW-25318
- Removal of deprecated methods usage - isApplicable
- Removal of deprecated methods class - ServiceManager
- Removal of deprecated constructor usage - TreeSpeedSearch